### PR TITLE
Adding mac address to the ovs plug interface

### DIFF
--- a/OSP-MutliNetwork-UPerf.sh
+++ b/OSP-MutliNetwork-UPerf.sh
@@ -252,8 +252,9 @@ if $PLUG ; then
  echo $PORT_SUB
  sleep 5
  service neutron-openvswitch-agent restart
- ip l s up $OVSPLUG
+ ip link set address $MAC_ID dev $OVSPLUG
  ip a a ${IP_ADDY}/${PORT_SUB} dev $OVSPLUG
+ ip l s up $OVSPLUG
 fi
 
 #


### PR DESCRIPTION
Not adding this results in a garbage mac to be assigned to
the plug interface making it impossible to reach guests
without using namespaces. This patch fixes that.

Signed-off-by: Sindhur smallen3@ncsu.edu
