### PR TITLE
Assigning the vlan tag to the hack port

### DIFF
--- a/OSP-MutliNetwork-UPerf.sh
+++ b/OSP-MutliNetwork-UPerf.sh
@@ -215,6 +215,7 @@ cleanup() {
   done
   neutron subnet-delete $(neutron subnet-list | grep "${SUBNET}" | awk '{print $2}')
   neutron net-delete $NETWORK
+  ovs-vsctl del-port rook-${RUN}
  fi
 
  if $CLEAN_IMAGE ; then
@@ -414,6 +415,7 @@ while true ; do
   continue
  fi
  VLAN=`printf "%d" ${VLANID_HEX}`
+ ovs-vsctl set Port $OVSPLUG tag=$VLAN
  if $DEBUG ; then
   echo "#----------------------- Debug -------------------------------------------------"
   echo "VLAN :: $VLAN"


### PR DESCRIPTION
When using a firewall driver other than iptables_hybrid
the tag is not assigned automatically to the hack port, due to which
network reachchability to guests on compute nodes is lost
- This patch also adds functionality to delete the hack port at the end of run
  which was mistakenly removed by earlier commit d7cb31203e9a2c4efd77f5406c94d31e62ac5da0

Signed-off-by: Sindhur smallen3@ncsu.edu
